### PR TITLE
Fix white empty page bug discussed in #6

### DIFF
--- a/BottomBar.Droid/Renderers/BottomBarPageRenderer.cs
+++ b/BottomBar.Droid/Renderers/BottomBarPageRenderer.cs
@@ -206,8 +206,7 @@ namespace BottomBar.Droid.Renderers
 			int tabsHeight = Math.Min (height, Math.Max (_bottomBar.MeasuredHeight, _bottomBar.MinimumHeight));
 
 			if (width > 0 && height > 0) {
-				int ninePercentsOfHeight = (int)Math.Ceiling((height * 0.909));
-				_pageController.ContainerArea = new Rectangle(0, 0, context.FromPixels(width), context.FromPixels(ninePercentsOfHeight));
+				_pageController.ContainerArea = new Rectangle(0, 0, context.FromPixels(width), context.FromPixels(_frameLayout.Height));
 				ObservableCollection<Element> internalChildren = _pageController.InternalChildren;
 
 				for (var i = 0; i < internalChildren.Count; i++) {

--- a/BottomBar.nuspec
+++ b/BottomBar.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ThriveGmbH.BottomNavigationBar.XF</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>BottomNavigationBar for Xamarin Forms</title>
     <authors>Sebastian Schmidt</authors>
     <licenseUrl>https://github.com/thrive-now/BottomNavigationBarXF/blob/master/LICENSE</licenseUrl>


### PR DESCRIPTION
Replace magic number 0.909 and height calculation for ContainerArea discussed in issue #6.

I've approximately calculated the 0.909 value of page height to be the correct size of the **ContainerArea** property  for the BottomBarPage, but seems I was wrong. That is working on most of the devices, but I discovered it is still buggy on some non-standard displays like the Galaxy Note 3, which features 5.7" display, and the Xiaomi Redmi Note 3 Pro. Therefore I've played around with getting the real child's height and it seems to be working great with the **_frameLayout**'s **Height** property.