### PR TITLE
Enables badges on Android with bindable badge count and badge color

### DIFF
--- a/BottomBar.Droid/Renderers/BottomBarPageRenderer.cs
+++ b/BottomBar.Droid/Renderers/BottomBarPageRenderer.cs
@@ -352,6 +352,9 @@ namespace BottomBar.Droid.Renderers
 	        }
 	        else
 	        {
+                // Don't need to create a badge when there's no badge to show
+	            if (badgeCount == 0) return;
+
                 // BottomBarBadge does not allow us to set color after init. You could, but you'd have to
                 // do it manually because the circle background logic is hidden from us
 	            var badgeColor = BottomBarPageExtensions.GetBadgeColor(page);

--- a/BottomBar.XamarinForms/BottomBarPageExtensions.cs
+++ b/BottomBar.XamarinForms/BottomBarPageExtensions.cs
@@ -28,6 +28,18 @@ namespace BottomBar.XamarinForms
                 typeof(BottomBarPageExtensions),
                 Color.Transparent);
 
+        public static readonly BindableProperty BadgeCountProperty = BindableProperty.CreateAttached(
+            "BadgeCount",
+            typeof(int),
+            typeof(BottomBarPageExtensions),
+            0);
+
+        public static readonly BindableProperty BadgeColorProperty = BindableProperty.CreateAttached(
+            "BadgeColor",
+            typeof(Color),
+            typeof(BottomBarPageExtensions),
+            Color.Red);
+
         public static void SetTabColor(BindableObject bindable, Color color)
         {
             bindable.SetValue(TabColorProperty, color);
@@ -36,6 +48,26 @@ namespace BottomBar.XamarinForms
         public static Color GetTabColor(BindableObject bindable)
         {
             return (Color)bindable.GetValue(TabColorProperty);
+        }
+
+        public static void SetBadgeCount(BindableObject bindable, int badgeCount)
+        {
+            bindable.SetValue(BadgeCountProperty, badgeCount);
+        }
+
+        public static int GetBadgeCount(BindableObject bindable)
+        {
+            return (int)bindable.GetValue(BadgeCountProperty);
+        }
+
+        public static void SetBadgeColor(BindableObject bindable, Color color)
+        {
+            bindable.SetValue(BadgeColorProperty, color);
+        }
+
+        public static Color GetBadgeColor(BindableObject bindable)
+        {
+            return (Color)bindable.GetValue(BadgeColorProperty);
         }
 
         #endregion

--- a/example-xaml/BottomBarXFExampleXaml.Droid/BottomBarXFExampleXaml.Droid.csproj
+++ b/example-xaml/BottomBarXFExampleXaml.Droid/BottomBarXFExampleXaml.Droid.csproj
@@ -9,14 +9,14 @@
     <OutputType>Library</OutputType>
     <RootNamespace>BottomBarXFExampleXaml.Droid</RootNamespace>
     <AssemblyName>BottomBarXFExampleXaml.Droid</AssemblyName>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <ReleaseVersion>0.8</ReleaseVersion>
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>

--- a/example-xaml/BottomBarXFExampleXaml/BarPage.xaml
+++ b/example-xaml/BottomBarXFExampleXaml/BarPage.xaml
@@ -7,6 +7,7 @@
   <example:TabPage Title="Favorites" Icon="ic_favorites.png" />
   <example:TabPage Title="Friends" Icon="ic_friends.png" xf:BottomBarPageExtensions.TabColor="#5D4037" />
   <example:TabPage Title="Nearby" Icon="ic_nearby.png" xf:BottomBarPageExtensions.TabColor="#7B1FA2" />
-  <example:TabPage Title="Recents" Icon="ic_recents.png" xf:BottomBarPageExtensions.TabColor="#FF5252" />
+  <example:TabPage Title="Recents" Icon="ic_recents.png" xf:BottomBarPageExtensions.TabColor="#FF5252"
+                   xf:BottomBarPageExtensions.BadgeCount="2" xf:BottomBarPageExtensions.BadgeColor="Black"/>
   <example:TabPage Title="Restaurants" Icon="ic_restaurants.png" xf:BottomBarPageExtensions.TabColor="#FF9800" />
 </xf:BottomBarPage>

--- a/example/BottomBarXFExample.Droid/BottomBarXFExample.Droid.csproj
+++ b/example/BottomBarXFExample.Droid/BottomBarXFExample.Droid.csproj
@@ -9,14 +9,14 @@
     <OutputType>Library</OutputType>
     <RootNamespace>BottomBarXFExample.Droid</RootNamespace>
     <AssemblyName>BottomBarXFExample.Droid</AssemblyName>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <ReleaseVersion>0.8</ReleaseVersion>
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>

--- a/example/BottomBarXFExample.Droid/Properties/AndroidManifest.xml
+++ b/example/BottomBarXFExample.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.test.bottombarxf">
-	<uses-sdk android:minSdkVersion="16" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.test.bottombarxf" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="25" />
 	<application android:label="BottomBarXFExample"></application>
 </manifest>

--- a/example/BottomBarXFExample/App.xaml.cs
+++ b/example/BottomBarXFExample/App.xaml.cs
@@ -38,10 +38,14 @@ namespace BottomBarXFExample
 
             string[] tabTitles = { "Favorites", "Friends", "Nearby", "Recents", "Restaurants" };
 			string [] tabColors = { null, "#5D4037", "#7B1FA2", "#FF5252", "#FF9800" };
+		    int[] tabBadgeCounts = {0, 1, 5, 3, 4};
+		    string[] tabBadgeColors = {"#000000", "#FF0000", "#000000", "#000000", "#000000"};
 
 			for (int i = 0; i < tabTitles.Length; ++i) {
 				string title = tabTitles [i];
 				string tabColor = tabColors [i];
+			    int tabBadgeCount = tabBadgeCounts[i];
+			    string tabBadgeColor = tabBadgeColors[i];
 
 				FileImageSource icon = (FileImageSource) FileImageSource.FromFile (string.Format ("ic_{0}.png", title.ToLowerInvariant ()));
 
@@ -55,6 +59,10 @@ namespace BottomBarXFExample
 				if (tabColor != null) {
                     BottomBarPageExtensions.SetTabColor(tabPage, Color.FromHex(tabColor));
 				}
+
+                // Set badges
+                BottomBarPageExtensions.SetBadgeCount(tabPage, tabBadgeCount);
+                BottomBarPageExtensions.SetBadgeColor(tabPage, Color.FromHex(tabBadgeColor));
 
 				// set label based on title
 				tabPage.UpdateLabel ();


### PR DESCRIPTION
This pull request includes some changes to the BottomBarPageRenderer and Extension classes to allow simple badge support on Android.

You can add a badge count and color using the new attached properties BadgeCount and BadgeColor. BadgeColor is bindable but the badge color won't change dynamically due to limitations in the underlying BottomBarBadge class.

I have not included iOS badge support although this can be achieved with a custom TabbedPage renderer using the same attached properties. 